### PR TITLE
Switch to CSS grid better layout + customizability

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ To customize the UI, you can either:
 
 **default value**: `'ha'`
 
-#### `margin`
+#### `margin` (removed in v3.0, use `columnGap` and `rowGap` instead)
 
 **type**: `number`
 
@@ -155,6 +155,26 @@ To customize the UI, you can either:
 **required**: no
 
 **default value**: `3`
+
+#### `columnGap`
+
+**type**: `string`
+
+**description**: The gap between grid columns, specified using any valid CSS units
+
+**required**: no
+
+**default value**: `'4 px'`
+
+#### `rowGap`
+
+**type**: `string`
+
+**description**: The gap between grid rows, specified using any valid CSS units
+
+**required**: no
+
+**default value**: `'4 px'`
 
 #### `unselectedColor`
 
@@ -188,8 +208,24 @@ To customize the UI, you can either:
 
 #### `renderDateCell`
 
-**type**: `(time: Date, selected: boolean, refSetter: (dateCell: HTMLElement | null) => void) => React.Node`
+**type**: `(datetime: Date, selected: boolean, refSetter: (dateCell: HTMLElement | null) => void) => React.Node`
 
 **description**: A render prop function that accepts the time this cell is representing and whether the cell is selected or not and should return a React element. It is your responsibility to apply the `refSetter` as a ref to the component you render -- neglecting to do so will cause the component to not work properly for touch devices. If you choose to use this custom render function, the color props above have no effect.
+
+**required**: no
+
+#### `renderTimeLabel`
+
+**type**: `(time: Date) => React.Node`
+
+**description**: A render prop function that accepts the time a given row is representing and should return a React element.
+
+**required**: no
+
+#### `renderDateLabel`
+
+**type**: `(date: Date) => React.Node`
+
+**description**: A render prop function that accepts the time a given row is representing and should return a React element.
 
 **required**: no

--- a/src/lib/ScheduleSelector.js
+++ b/src/lib/ScheduleSelector.js
@@ -32,6 +32,7 @@ const Grid = styled.div`
 `
 
 export const GridCell = styled.div`
+  place-self: stretch;
   touch-action: none;
 `
 

--- a/test/lib/ScheduleSelector.test.js
+++ b/test/lib/ScheduleSelector.test.js
@@ -127,17 +127,21 @@ describe('ScheduleSelector', () => {
       spies.onTouchEnd = jest.spyOn(ScheduleSelector.prototype, 'handleTouchEndEvent')
       component = shallow(<ScheduleSelector />)
       anInstance = component.find('.rgdp__grid-cell').first()
-      mockEvent.touches = [{ clientX: 1, clientY: 2 }, { clientX: 100, clientY: 200 }]
+      mockEvent.touches = [
+        { clientX: 1, clientY: 2 },
+        { clientX: 100, clientY: 200 }
+      ]
     })
 
-    test.each([['onTouchStart', []], ['onTouchMove', [mockEvent]], ['onTouchEnd', []]])(
-      'calls the handler for %s',
-      (name, args) => {
-        anInstance.prop(name)(...args)
-        expect(spies[name]).toHaveBeenCalled()
-        spies[name].mockClear()
-      }
-    )
+    test.each([
+      ['onTouchStart', []],
+      ['onTouchMove', [mockEvent]],
+      ['onTouchEnd', []]
+    ])('calls the handler for %s', (name, args) => {
+      anInstance.prop(name)(...args)
+      expect(spies[name]).toHaveBeenCalled()
+      spies[name].mockClear()
+    })
 
     afterAll(() => {
       Object.keys(spies).forEach(spyName => {
@@ -160,7 +164,12 @@ describe('ScheduleSelector', () => {
   })
 
   describe('updateAvailabilityDraft', () => {
-    it.each([['add', 1], ['remove', 1], ['add', -1], ['remove', -1]])(
+    it.each([
+      ['add', 1],
+      ['remove', 1],
+      ['add', -1],
+      ['remove', -1]
+    ])(
       'updateAvailabilityDraft handles addition and removals, for forward and reversed drags',
       (type, amount, done) => {
         const start = moment(startDate)
@@ -298,10 +307,10 @@ describe('ScheduleSelector', () => {
     it('splits hours using the hourlyChunks prop', () => {
       // 15-minute resolution
       const component = shallow(<ScheduleSelector minTime={1} maxTime={2} hourlyChunks={4} />)
-      expect(component.find('ScheduleSelector__TimeLabelCell')).toHaveLength(4)
+      expect(component.find('ScheduleSelector__TimeText')).toHaveLength(4)
       // 5-minute resolution
       const componentTwo = shallow(<ScheduleSelector minTime={1} maxTime={2} hourlyChunks={12} />)
-      expect(componentTwo.find('ScheduleSelector__TimeLabelCell')).toHaveLength(12)
+      expect(componentTwo.find('ScheduleSelector__TimeText')).toHaveLength(12)
     })
 
     it('formats the time column using the timeFormat prop', () => {
@@ -309,7 +318,7 @@ describe('ScheduleSelector', () => {
       const component = shallow(<ScheduleSelector minTime={1} maxTime={2} timeFormat="h:mma" hourlyChunks={4} />)
       expect(
         component
-          .find('ScheduleSelector__TimeLabelCell')
+          .find('ScheduleSelector__TimeText')
           .at(1)
           .render()
           .text()
@@ -318,7 +327,7 @@ describe('ScheduleSelector', () => {
       const componentTwo = shallow(<ScheduleSelector minTime={1} maxTime={2} timeFormat="h:mma" hourlyChunks={12} />)
       expect(
         componentTwo
-          .find('ScheduleSelector__TimeLabelCell')
+          .find('ScheduleSelector__TimeText')
           .at(1)
           .render()
           .text()

--- a/test/lib/__snapshots__/ScheduleSelector.test.js.snap
+++ b/test/lib/__snapshots__/ScheduleSelector.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScheduleSelector snapshot tests renders correctly with custom render prop 1`] = `
-.c3 {
+.c2 {
   font-size: 20px;
   font-weight: 400;
   color: rgba(79,79,79,1);
   text-align: center;
 }
 
-.c6 {
+.c4 {
   font-size: 14px;
   font-weight: 300;
   line-height: 19.18px;
@@ -33,87 +33,42 @@ exports[`ScheduleSelector snapshot tests renders correctly with custom render pr
 }
 
 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: auto repeat(5,1fr);
+  grid-template-rows: auto repeat(14,1fr);
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+  row-gap: 4px;
   width: 100%;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: space-evenly;
-  -webkit-justify-content: space-evenly;
-  -ms-flex-pack: space-evenly;
-  justify-content: space-evenly;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c8 {
-  margin: 3px;
+.c6 {
   touch-action: none;
 }
 
-.c4 {
-  height: 30px;
+.c3 {
+  margin: 0;
 }
 
 .c5 {
-  position: relative;
-  display: block;
-  width: 100%;
-  height: 25px;
-  margin: 3px 0;
-  text-align: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c7 {
   margin: 0;
   text-align: right;
 }
 
 @media (max-width:700px) {
-  .c3 {
+  .c2 {
     font-size: 18px;
   }
 }
 
 @media (max-width:699px) {
-  .c4 {
+  .c3 {
     font-size: 12px;
   }
 }
 
 @media (max-width:699px) {
-  .c7 {
+  .c5 {
     font-size: 10px;
   }
 }
@@ -123,1323 +78,1222 @@ exports[`ScheduleSelector snapshot tests renders correctly with custom render pr
 >
   <div
     className="c1"
+    rows={14}
   >
-    <div
-      className="c2"
+    <div />
+    <h2
+      className="c2 c3"
     >
-      <h2
-        className="c3 c4"
-      />
+      1/1
+    </h2>
+    <h2
+      className="c2 c3"
+    >
+      1/2
+    </h2>
+    <h2
+      className="c2 c3"
+    >
+      1/3
+    </h2>
+    <h2
+      className="c2 c3"
+    >
+      1/4
+    </h2>
+    <h2
+      className="c2 c3"
+    >
+      1/5
+    </h2>
+    <p
+      className="c4 c5"
+    >
+      9am
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c5"
+        className="false test-date-cell-renderer"
       >
-        <p
-          className="c6 c7"
-        >
-          9am
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          10am
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          11am
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          12pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          1pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          2pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          3pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          4pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          5pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          6pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          7pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          8pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          9pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          10pm
-        </p>
+        Mon Jan 01 2018
       </div>
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
-        className="c8"
+        className="false test-date-cell-renderer"
       >
-        <h2
-          className="c3 c4"
-        >
-          1/1
-        </h2>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="selected test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Mon Jan 01 2018
-        </div>
+        Mon Jan 01 2018
       </div>
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
-        className="c8"
+        className="false test-date-cell-renderer"
       >
-        <h2
-          className="c3 c4"
-        >
-          1/2
-        </h2>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="selected test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Tue Jan 02 2018
-        </div>
+        Mon Jan 01 2018
       </div>
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
-        className="c8"
+        className="selected test-date-cell-renderer"
       >
-        <h2
-          className="c3 c4"
-        >
-          1/3
-        </h2>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Wed Jan 03 2018
-        </div>
+        Mon Jan 01 2018
       </div>
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
-        className="c8"
+        className="false test-date-cell-renderer"
       >
-        <h2
-          className="c3 c4"
-        >
-          1/4
-        </h2>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      10am
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Thu Jan 04 2018
-        </div>
+        Mon Jan 01 2018
       </div>
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
-        className="c8"
+        className="false test-date-cell-renderer"
       >
-        <h2
-          className="c3 c4"
-        >
-          1/5
-        </h2>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      11am
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Mon Jan 01 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Tue Jan 02 2018
       </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      12pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Tue Jan 02 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Tue Jan 02 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Tue Jan 02 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="selected test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Tue Jan 02 2018
       </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Tue Jan 02 2018
       </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      1pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
+        className="false test-date-cell-renderer"
       >
-        <div
-          className="false test-date-cell-renderer"
-        >
-          Fri Jan 05 2018
-        </div>
+        Tue Jan 02 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Tue Jan 02 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Tue Jan 02 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Tue Jan 02 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Tue Jan 02 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      2pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Tue Jan 02 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Tue Jan 02 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Tue Jan 02 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      3pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      4pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      5pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Wed Jan 03 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      6pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      7pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      8pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Thu Jan 04 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      9pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <p
+      className="c4 c5"
+    >
+      10pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
+      </div>
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="false test-date-cell-renderer"
+      >
+        Fri Jan 05 2018
       </div>
     </div>
   </div>
@@ -1447,14 +1301,14 @@ exports[`ScheduleSelector snapshot tests renders correctly with custom render pr
 `;
 
 exports[`ScheduleSelector snapshot tests renders correctly with default render logic 1`] = `
-.c3 {
+.c2 {
   font-size: 20px;
   font-weight: 400;
   color: rgba(79,79,79,1);
   text-align: center;
 }
 
-.c6 {
+.c4 {
   font-size: 14px;
   font-weight: 300;
   line-height: 19.18px;
@@ -1479,107 +1333,62 @@ exports[`ScheduleSelector snapshot tests renders correctly with default render l
 }
 
 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: auto repeat(5,1fr);
+  grid-template-rows: auto repeat(14,1fr);
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+  row-gap: 4px;
   width: 100%;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: space-evenly;
-  -webkit-justify-content: space-evenly;
-  -ms-flex-pack: space-evenly;
-  justify-content: space-evenly;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c8 {
-  margin: 3px;
+.c6 {
   touch-action: none;
 }
 
-.c9 {
+.c7 {
   width: 100%;
   height: 25px;
   background-color: #dbedff;
 }
 
-.c9:hover {
+.c7:hover {
   background-color: rgba(162,198,248,1);
 }
 
-.c10 {
+.c8 {
   width: 100%;
   height: 25px;
   background-color: rgba(89,154,242,1);
 }
 
-.c10:hover {
+.c8:hover {
   background-color: rgba(162,198,248,1);
 }
 
-.c4 {
-  height: 30px;
+.c3 {
+  margin: 0;
 }
 
 .c5 {
-  position: relative;
-  display: block;
-  width: 100%;
-  height: 25px;
-  margin: 3px 0;
-  text-align: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c7 {
   margin: 0;
   text-align: right;
 }
 
 @media (max-width:700px) {
-  .c3 {
+  .c2 {
     font-size: 18px;
   }
 }
 
 @media (max-width:699px) {
-  .c4 {
+  .c3 {
     font-size: 12px;
   }
 }
 
 @media (max-width:699px) {
-  .c7 {
+  .c5 {
     font-size: 10px;
   }
 }
@@ -1589,1254 +1398,1153 @@ exports[`ScheduleSelector snapshot tests renders correctly with default render l
 >
   <div
     className="c1"
+    rows={14}
   >
-    <div
-      className="c2"
+    <div />
+    <h2
+      className="c2 c3"
     >
-      <h2
-        className="c3 c4"
+      1/1
+    </h2>
+    <h2
+      className="c2 c3"
+    >
+      1/2
+    </h2>
+    <h2
+      className="c2 c3"
+    >
+      1/3
+    </h2>
+    <h2
+      className="c2 c3"
+    >
+      1/4
+    </h2>
+    <h2
+      className="c2 c3"
+    >
+      1/5
+    </h2>
+    <p
+      className="c4 c5"
+    >
+      9am
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
       />
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          9am
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          10am
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          11am
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          12pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          1pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          2pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          3pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          4pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          5pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          6pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          7pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          8pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          9pm
-        </p>
-      </div>
-      <div
-        className="c5"
-      >
-        <p
-          className="c6 c7"
-        >
-          10pm
-        </p>
-      </div>
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
         className="c8"
-      >
-        <h2
-          className="c3 c4"
-        >
-          1/1
-        </h2>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c10"
-          selected={true}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        selected={true}
+      />
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      10am
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      11am
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      12pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
         className="c8"
-      >
-        <h2
-          className="c3 c4"
-        >
-          1/2
-        </h2>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c10"
-          selected={true}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        selected={true}
+      />
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
-        className="c8"
-      >
-        <h2
-          className="c3 c4"
-        >
-          1/3
-        </h2>
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      1pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
-        className="c8"
-      >
-        <h2
-          className="c3 c4"
-        >
-          1/4
-        </h2>
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
-      <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
     </div>
     <div
-      className="c2"
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
     >
       <div
-        className="c8"
-      >
-        <h2
-          className="c3 c4"
-        >
-          1/5
-        </h2>
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      2pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      3pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      4pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
       <div
-        className="c8 rgdp__grid-cell"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        role="presentation"
-      >
-        <div
-          className="c9"
-          selected={false}
-        />
-      </div>
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      5pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      6pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      7pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      8pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      9pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <p
+      className="c4 c5"
+    >
+      10pm
+    </p>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
+    </div>
+    <div
+      className="c6 rgdp__grid-cell"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      role="presentation"
+    >
+      <div
+        className="c7"
+        selected={false}
+      />
     </div>
   </div>
 </div>

--- a/test/lib/__snapshots__/ScheduleSelector.test.js.snap
+++ b/test/lib/__snapshots__/ScheduleSelector.test.js.snap
@@ -43,16 +43,19 @@ exports[`ScheduleSelector snapshot tests renders correctly with custom render pr
 }
 
 .c6 {
+  place-self: stretch;
   touch-action: none;
 }
 
 .c3 {
   margin: 0;
+  margin-bottom: 4px;
 }
 
 .c5 {
-  margin: 0;
   text-align: right;
+  margin: 0;
+  margin-right: 4px;
 }
 
 @media (max-width:700px) {
@@ -1343,6 +1346,7 @@ exports[`ScheduleSelector snapshot tests renders correctly with default render l
 }
 
 .c6 {
+  place-self: stretch;
   touch-action: none;
 }
 
@@ -1368,11 +1372,13 @@ exports[`ScheduleSelector snapshot tests renders correctly with default render l
 
 .c3 {
   margin: 0;
+  margin-bottom: 4px;
 }
 
 .c5 {
-  margin: 0;
   text-align: right;
+  margin: 0;
+  margin-right: 4px;
 }
 
 @media (max-width:700px) {


### PR DESCRIPTION
Changes the core grid to use CSS Grid rather than Flexbox. This ensures that the layout behaves more predictably and is easier to customize. In the process, this also introduces a few new props: `renderTimeLabel`, `renderDateLabel`, `columnGap`, and `rowGap` and removes one old prop: `margin`. Not much changes visually/functionally.

![image](https://user-images.githubusercontent.com/8083680/97092227-2104cc00-15f7-11eb-9ad5-85e3f51e4f69.png)
